### PR TITLE
feat: support loading password from keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ You could probably get this working for mpv on other operating systems.
 
 3. Copy the `lastfmscrobbler` folder and the `scripts` folder into `~/.config/mpv/`
 
-4. Open `lastfmscrobbler/scrobble.sh` and modify the following lines with your last.fm login:
+4. Open `lastfmscrobbler/scrobble.sh` and modify the `USERNAME` variable:
 ```
-USERNAME = 'myUsername'
-PASSWORD = 'myPassword'
+USERNAME='lastfmUsername'
+```
+
+5. In a terminal, write your last.fm password to the `login` keychain, under the `com.iina.lastfm` service:
+```
+security add-generic-password -a "lastfmUsername" -s "com.iina.lastfm" -w "mypassword"
 ```
 
 

--- a/lastfmscrobbler/scrobble.sh
+++ b/lastfmscrobbler/scrobble.sh
@@ -6,8 +6,13 @@ tentativeMetadata=$(echo '{ "command": ["get_property", "metadata"] }' | /usr/bi
 
 sleep 4
 
-USERNAME="" # CHANGE ME
-PASSWORD="" # CHANGE ME
+USERNAME='' # CHANGE ME
+
+KEYCHAIN_SERVICE='com.iina.lastfm'
+# Retrieve password from the keychain
+# Ensure you've added it first using `security add-generic-password -a "<lastfmUsername> -s "com.iina.lastfm" -w "<password>"`
+PASSWORD=$(security find-generic-password -a "$USERNAME" -s "$KEYCHAIN_SERVICE" -w)
+
 APIKEY="3176eb0bd0ff5d1c8f15d94e3b3c98a8"      # Change if the script stops working
 APISECRET="2918fac730f44f543d2568f9976ec276"   # Change if the script stops working
 

--- a/lastfmscrobbler/scrobble.sh
+++ b/lastfmscrobbler/scrobble.sh
@@ -10,7 +10,7 @@ USERNAME='' # CHANGE ME
 
 KEYCHAIN_SERVICE='com.iina.lastfm'
 # Retrieve password from the keychain
-# Ensure you've added it first using `security add-generic-password -a "<lastfmUsername> -s "com.iina.lastfm" -w "<password>"`
+# Ensure you've added it first using `security add-generic-password -a "lastfmUsername" -s "com.iina.lastfm" -w "mypassword"`
 PASSWORD=$(security find-generic-password -a "$USERNAME" -s "$KEYCHAIN_SERVICE" -w)
 
 APIKEY="3176eb0bd0ff5d1c8f15d94e3b3c98a8"      # Change if the script stops working


### PR DESCRIPTION
Closes #14.

Not sure why I didn't think of the Keychain, but reading and writing from the user `login` keychain doesn't require sudo (and therefore doesn't cause the app to prompt the user for their password, or anything). 